### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/mbta_predictions/manifest.json
+++ b/custom_components/mbta_predictions/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://github.com/dhanani94/mbta_predictions",
   "dependencies": [],
   "codeowners": ["dhanani94", "MikeFez"],
-  "requirements": []
+  "requirements": [],
+  "version": "1.0"
 }


### PR DESCRIPTION
Fixing an issue with Home Assistant version 2021.6 not running MBTA predictions as version key is now mandatory.