### PR TITLE
device_state_attributes is no longer called

### DIFF
--- a/custom_components/mbta_predictions/sensor.py
+++ b/custom_components/mbta_predictions/sensor.py
@@ -167,7 +167,7 @@ class MBTASensor(Entity):
             return self._arrival_data[0]['departure']
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes """
         logging.debug("returing attributes")
         return {


### PR DESCRIPTION
Instead it needs to be `extra_state_attributes`

See https://github.com/home-assistant/core/pull/47304

This change is needed for compatibility with HA 2022.4